### PR TITLE
Update to 3.26.2

### DIFF
--- a/ca.desrt.dconf-editor.json
+++ b/ca.desrt.dconf-editor.json
@@ -2,7 +2,7 @@
     "id": "ca.desrt.dconf-editor",
     "base-version": "master",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.24",
+    "runtime-version": "3.26",
     "sdk": "org.gnome.Sdk",
     "command": "dconf-editor",
     "rename-icon": "dconf-editor",
@@ -21,8 +21,8 @@
         "sources": [
             {
                 "type": "archive",
-                "url": "http://ftp.gnome.org/pub/GNOME/sources/dconf-editor/3.22/dconf-editor-3.22.3.tar.xz",
-                "sha256": "55f167d7e61714766406b23d7222d509f7bb98b9df1a367113ac14ea06f669a4"
+                "url": "http://ftp.gnome.org/pub/GNOME/sources/dconf-editor/3.26/dconf-editor-3.26.2.tar.xz",
+                "sha256": "28b453fe49c49d7dfaf07c85c01d7495913f93ab64a0b223c117eb17d1cb8ad1"
             }
         ]
     }


### PR DESCRIPTION
3.28.0 doesn't build with 3.28 runtime at the moment with
`Invalid version of dependency, need 'gtk+-3.0' ['>= 3.22.27'] found '3.22.26'.`
So at least updated it to 3.26.