### PR TITLE
Support reading host schemas

### DIFF
--- a/ca.desrt.dconf-editor.json
+++ b/ca.desrt.dconf-editor.json
@@ -3,32 +3,46 @@
     "runtime": "org.gnome.Platform",
     "runtime-version": "3.32",
     "sdk": "org.gnome.Sdk",
-    "command": "dconf-editor",
+    "command": "start-dconf-editor",
     "finish-args": [
         "--share=ipc",
         "--socket=x11",
         "--socket=wayland",
         "--talk-name=ca.desrt.dconf",
         "--filesystem=xdg-run/dconf",
-        "--filesystem=~/.config/dconf:ro",
+        "--filesystem=host:ro",
         "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
+        "--talk-name=org.freedesktop.Flatpak",
         "--talk-name=org.gnome.SettingsDaemon.Color"
     ],
     "modules": [
-    {
-        "name": "dconf-editor",
-        "buildsystem": "meson",
-        "sources": [
-            {
-                "type": "archive",
-                "url": "https://download.gnome.org/sources/dconf-editor/3.32/dconf-editor-3.32.0.tar.xz",
-                "sha256": "f19d1332ac27e23ef3dc2ed07ba4e4646d9d7f05e2e78748aa525a1320adbaba"
-            },
-            {
-                "type": "patch",
-                "path": "0001-Add-some-more-appdata-fields-for-Flatpak.patch"
-            }
-        ]
-    }
+        {
+            "name": "dconf-editor",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/dconf-editor/3.32/dconf-editor-3.32.0.tar.xz",
+                    "sha256": "f19d1332ac27e23ef3dc2ed07ba4e4646d9d7f05e2e78748aa525a1320adbaba"
+                },
+                {
+                    "type": "patch",
+                    "path": "0001-Add-some-more-appdata-fields-for-Flatpak.patch"
+                }
+            ]
+        },
+        {
+            "name": "scripts",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install -Dm 755 start-dconf-editor.sh /app/bin/start-dconf-editor"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "path": "start-dconf-editor.sh"
+                }
+            ]
+        }
     ]
 }

--- a/start-dconf-editor.sh
+++ b/start-dconf-editor.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/bash
+
+IFS=: read -ra host_data_dirs < <(flatpak-spawn --host sh -c 'echo $XDG_DATA_DIRS')
+
+# To avoid potentially muddying up $XDG_DATA_DIRS too much, we link the schema paths
+# into a temporary directory.
+bridge_dir=$XDG_RUNTIME_DIR/dconf-bridge
+mkdir -p "$bridge_dir"
+
+for dir in "${host_data_dirs[@]}"; do
+  if [[ "$dir" == /usr/* ]]; then
+    dir=/run/host/"$dir"
+  fi
+
+  schemas="$dir/glib-2.0/schemas"
+  if [[ -d "$schemas" ]]; then
+    bridged=$(mktemp -d XXXXXXXXXX -p "$bridge_dir")
+    mkdir -p "$bridged"/glib-2.0
+    ln -s "$schemas" "$bridged"/glib-2.0
+    XDG_DATA_DIRS=$XDG_DATA_DIRS:"$bridged"
+  fi
+done
+
+export XDG_DATA_DIRS
+exec dconf-editor "$@"


### PR DESCRIPTION
Closes #3. Pretty simple overall, I just update XDG_DATA_DIRS in the Flatpak, but use symlinks to avoid polluting it with other host stuff we may not actually want.