### PR TITLE
Set GIO_EXTRA_MODULES to hint at libdconf location

### DIFF
--- a/ca.desrt.dconf-editor.json
+++ b/ca.desrt.dconf-editor.json
@@ -12,6 +12,7 @@
         "--filesystem=xdg-run/dconf",
         "--filesystem=host:ro",
         "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
+        "--env=GIO_EXTRA_MODULES=/app/lib/gio/modules/",
         "--talk-name=org.freedesktop.Flatpak",
         "--talk-name=org.gnome.SettingsDaemon.Color"
     ],


### PR DESCRIPTION
Inspired by https://src.fedoraproject.org/flatpaks/dconf-editor/c/9a91b41133369cfbc5424bc7e3cb1e2df86d7dae?branch=stable

Before, the dconf-editor flatpak would not be able to read certain (all?) values, for instance custom-keybindings.