### PR TITLE
fix: correct the desktop shortcut so that it can see host schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/.flatpak-builder
+/build-dir
+/build
+/export

--- a/ca.desrt.dconf-editor.json
+++ b/ca.desrt.dconf-editor.json
@@ -58,7 +58,8 @@
                 }
             ],
             "post-install": [
-                "sed -i 's,^Exec=dconf-editor$,Exec=start-dconf-editor,g' /app/share/applications/ca.desrt.dconf-editor.desktop"
+                "sed -i 's,^Exec=dconf-editor$,Exec=start-dconf-editor,g' /app/share/applications/ca.desrt.dconf-editor.desktop",
+                "sed -i 's,^Exec=/app/bin/dconf-editor,Exec=/app/bin/start-dconf-editor,g' /app/share/dbus-1/services/ca.desrt.dconf-editor.service"
             ]
         },
         {

--- a/ca.desrt.dconf-editor.json
+++ b/ca.desrt.dconf-editor.json
@@ -56,6 +56,9 @@
                         "is-important": true
                     }
                 }
+            ],
+            "post-install": [
+                "sed -i 's,^Exec=dconf-editor$,Exec=start-dconf-editor,g' /app/share/applications/ca.desrt.dconf-editor.desktop"
             ]
         },
         {


### PR DESCRIPTION
We were exporting a `.desktop` file that ran the plain "dconf-editor" without the necessary wrapper, which meant that the Flatpak version of dconf-editor was unable to see any schemas from the host. Serious bug. Simple fix! :)

Closes #19.