### PR TITLE
fix: correctly prioritize the host's gschema instead of the flatpak's

### DIFF
--- a/start-dconf-editor.sh
+++ b/start-dconf-editor.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/bash
 
-IFS=: read -ra host_data_dirs < <(flatpak-spawn --host sh -c 'echo $XDG_DATA_DIRS')
+IFS=: read -ra host_data_dirs < <(flatpak-spawn --host sh -c 'echo "$XDG_DATA_DIRS"')
 
 # To avoid potentially muddying up $XDG_DATA_DIRS too much, we link the schema paths
 # into a temporary directory.
 bridge_dir=$XDG_RUNTIME_DIR/dconf-bridge
 mkdir -p "$bridge_dir"
+
+HOST_XDG_DATA_DIRS=""
 
 for dir in "${host_data_dirs[@]}"; do
   if [[ "$dir" == /usr/* ]]; then
@@ -17,9 +19,16 @@ for dir in "${host_data_dirs[@]}"; do
     bridged=$(mktemp -d XXXXXXXXXX -p "$bridge_dir")
     mkdir -p "$bridged"/glib-2.0
     ln -s "$schemas" "$bridged"/glib-2.0
-    XDG_DATA_DIRS=$XDG_DATA_DIRS:"$bridged"
+    HOST_XDG_DATA_DIRS="${HOST_XDG_DATA_DIRS}:${bridged}"
   fi
 done
+
+# We MUST prepend the host's data dirs BEFORE the Flatpak environment's own dirs,
+# otherwise data (such as default values) load in the wrong order and would then
+# incorrectly prefer the Flatpak's internal defaults instead of the host's defaults!
+if [[ ! -z "${HOST_XDG_DATA_DIRS}" ]]; then
+  XDG_DATA_DIRS="${HOST_XDG_DATA_DIRS:1}:${XDG_DATA_DIRS}"
+fi
 
 export XDG_DATA_DIRS
 exec dconf-editor "$@"


### PR DESCRIPTION
The environment variable was being built in the wrong order, and was putting the Flatpak's data locations as the highest priority. This meant that dconf-editor showed *completely wrong* values for most settings in dconf, since it was looking at the default Flatpak environment rather than the host's dconf environment!

This has now been fixed to use the correct priority, putting all host paths first, and then the Flatpak's default locations after that as fallbacks.

Closes #25.